### PR TITLE
Improve ace integration

### DIFF
--- a/site/js/acify.js
+++ b/site/js/acify.js
@@ -149,9 +149,12 @@ window.log;
   * Turn block into a ace editor
   */
   CodeBlock.prototype.acify = function() {
+    var text = this.el.text();
+    var lineCount = text.split('\n').length;
+    var lineHeight;
 
     // make editor
-    this.editorEl.text(this.el.text());
+    this.editorEl.text(text);
     this.editor = ace.edit(this.editorEl[0]);
 
     // set options
@@ -163,10 +166,10 @@ window.log;
 
     // mark this block as having been acified
     $.data(this.el[0], 'acified', 'true');
+    lineHeight = this.editor.renderer.lineHeight;
 
     this.editorEl.css({
-      width: this.editorEl.parent().parent().width(),
-      height: this.editorEl.parent().parent().height()
+      height: lineHeight * lineCount
     });
     this.editor.resize();
   };

--- a/site/js/acify.js
+++ b/site/js/acify.js
@@ -139,11 +139,10 @@ window.log;
     });
 
     // now that we found the smallest indent, reassemble the lines
-    var newblock = "";
-    $.each(lines, function(n, line) {
-      newblock += line.slice(indent) + "\n";
-    });
-    this.el.text(newblock);
+    var newblock = $.map(lines, function(line) {
+      return line.slice(indent);
+    }).join('\n');
+    this.el.text($.trim(newblock));
   };
 
   /**

--- a/src/other/d3-chart.chart.yaml
+++ b/src/other/d3-chart.chart.yaml
@@ -11,8 +11,7 @@ methods:
   description: |
     Create a new chart constructor or return a previously-created chart
     constructor.
-    %div{ :style => 'height:150px'}
-      = toRunnableCodeBlock("api/d3-chart/d3.chart.create", nil, {:globals => "d3"})
+    = toRunnableCodeBlock("api/d3-chart/d3.chart.create", nil, {:globals => "d3"})
   params:
   -
     name: name
@@ -42,8 +41,7 @@ methods:
     inheritance so that new chart constructors may be defined in terms of
     existing chart constructors. Based on the `extend` function defined by
     Backbone.js
-    %div{ :style => 'height:200px'}
-      = toRunnableCodeBlock("api/d3-chart/d3.chart.extend", nil, {:globals => "d3"})
+    = toRunnableCodeBlock("api/d3-chart/d3.chart.extend", nil, {:globals => "d3"})
   params:
   -
     name: name
@@ -73,8 +71,7 @@ instance_properties:
   returns: d3 selection
   description: |
     The d3.selection in which the Chart instance is contained.
-    %div{ :style => 'height:200px'}
-      = toRunnableCodeBlock("api/d3-chart/d3.chart.base", nil, {:globals => "d3"})
+    = toRunnableCodeBlock("api/d3-chart/d3.chart.base", nil, {:globals => "d3"})
 
 instance_methods:
 -
@@ -137,8 +134,7 @@ instance_methods:
     Subscribe a handler to a "lifecycle event". These events (and only these
     events) are triggered when <code>Layer#draw</code> is invoked &mdash; see
     that method for more details on lifecycle events.
-    %div{ :style => 'height:300px'}
-      = toRunnableCodeBlock("api/d3-chart/d3.chart.on")
+    = toRunnableCodeBlock("api/d3-chart/d3.chart.on")
   params:
   -
     name: name
@@ -166,8 +162,7 @@ instance_methods:
     function will be invoked at the next occurance of the event and immediately
     unsubscribed. See <code>Chart.on</code> to subscribe a callback function
     to an event indefinitely.
-    %div{ :style => 'height:350px'}
-      = toRunnableCodeBlock("api/d3-chart/d3.chart.once")
+    = toRunnableCodeBlock("api/d3-chart/d3.chart.once")
   params:
   -
     name: name
@@ -199,8 +194,7 @@ instance_methods:
     from that event. When a <code>name</code> and <code>context</code> are
     specified (but <code>callback</code> is omitted), all events bound to the
     given event with the given context will be unsubscribed.
-    %div{ :style => 'height: 400px'}
-      = toRunnableCodeBlock("api/d3-chart/d3.chart.off")
+    = toRunnableCodeBlock("api/d3-chart/d3.chart.off")
   params:
   -
     name: name
@@ -231,8 +225,7 @@ instance_methods:
     previously-created layer and attach it to the chart with the specified
     `name`.
     <br>
-    %div{ :style => 'height:150px'}
-      = toDisplayCodeBlock("api/d3-chart/d3.chart.layer2")
+    = toDisplayCodeBlock("api/d3-chart/d3.chart.layer2")
     <br>
     If all three arguments are specified, initialize a new layer using
     the specified `selection` as a base passing along the specified `options`.
@@ -241,8 +234,7 @@ instance_methods:
     whenever this chart's `draw` is invoked and will receive the
     data (optionally modified by the chart's transform method.
     <br>
-    %div{ :style => 'height:400px'}
-      = toDisplayCodeBlock("api/d3-chart/d3.chart.layer")
+    = toDisplayCodeBlock("api/d3-chart/d3.chart.layer")
 
   params:
   -
@@ -309,8 +301,7 @@ instance_methods:
     Register or retrieve an "attachment" Chart. The "attachment" chart's `draw`
     method will be invoked whenever the containing chart's `draw` method is
     invoked.
-    %div{ :style => 'height:220px;'}
-      = toDisplayCodeBlock("api/d3-chart/d3.chart.mixin")
+    = toDisplayCodeBlock("api/d3-chart/d3.chart.mixin")
   params:
   -
     name: attachmentName

--- a/src/other/d3-chart.layer.yaml
+++ b/src/other/d3-chart.layer.yaml
@@ -15,8 +15,7 @@ methods:
     Defines a new layer on a selection or returns a reference to the selection
     corresponding to a layer by a specific name. Most of the time will be called on
     a chart, but can be called directly on a layer.
-    %div{ :style => 'height:300px'}
-      = toRunnableCodeBlock("api/d3-chart/d3.layer.create")
+    = toRunnableCodeBlock("api/d3-chart/d3.layer.create")
   params:
   -
     name: options
@@ -75,8 +74,7 @@ instance_methods:
     inside of the <code>dataBind</code>, <code>insert</code> and any lifecycle event callback
     methods where the default context is set to the layer or lifecycle selection
     (on which you can call this chart method.) See example for more details.
-    %div{ :style => 'height:400px'}
-      = toRunnableCodeBlock("api/d3-chart/d3.layer.chart")
+    = toRunnableCodeBlock("api/d3-chart/d3.layer.chart")
 -
   name: 'on'
   signature: 'layer.on(lifecycleEvent, handler, options)'

--- a/src/other/miso.column.yaml
+++ b/src/other/miso.column.yaml
@@ -10,8 +10,7 @@ methods:
   returns: Miso.Dataset.Column
   description: |
     Returns a new column.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.column.constructor")
+    = toRunnableCodeBlock("api/miso.column.constructor")
   params:
   -
     name: options
@@ -59,8 +58,7 @@ instance_methods:
   description: |
     Internal function used to return the numeric value of a given input in a column. Index is used
     as this is currently the return value for numeric coercion of string values.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.column.numericat")
+    = toRunnableCodeBlock("api/miso.column.numericat")
   params:
   -
     name: index
@@ -72,5 +70,4 @@ instance_methods:
   returns: undefined
   description: |
     Coerces all the data in the column's data array to the appropriate type.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.column.coerce")
+    = toRunnableCodeBlock("api/miso.column.coerce")

--- a/src/other/miso.dataset.yaml
+++ b/src/other/miso.dataset.yaml
@@ -12,8 +12,7 @@ methods:
   name: constructor
   description: |
     Returns a new dataset. See the creating datasets guide for detailed information.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataset.constructor")
+    = toRunnableCodeBlock("api/miso.dataset.constructor")
   #TODO Link to creating datasets guide
   signature: 'new Miso.Dataset( options )'
   returns: Miso.Dataset
@@ -149,8 +148,7 @@ instance_methods:
     this needs to be called before data can be accessed. Fetch returns a
     %a{ :href => 'https://github.com/wookiehangover/underscore.Deferred' } deferred
     which makes it simple to chain operations off async data requests.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataset.fetch")
+    = toRunnableCodeBlock("api/miso.dataset.fetch")
   params:
   -
     name: options
@@ -171,8 +169,7 @@ instance_methods:
   returns: Miso.Dataset.Column
   description: |
     Creates a new column and adds it to the dataset.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataset.addcolumn")
+    = toRunnableCodeBlock("api/miso.dataset.addcolumn")
   params:
   -
     name: column
@@ -241,8 +238,7 @@ instance_methods:
   description: |
     Adds a row to the dataset. This will fire <code>add</code> and <code>change</code>
     events on a syncable dataset.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataset.add")
+    = toRunnableCodeBlock("api/miso.dataset.add")
   params:
   -
     name: row
@@ -266,8 +262,7 @@ instance_methods:
   description: |
     Removes rows matching the passed filter from the dataset. This will fire <code>remove</code>
     and <code>change</code> events on a syncable dataset.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataset.remove")
+    = toRunnableCodeBlock("api/miso.dataset.remove")
   params:
   -
     name: filter
@@ -294,8 +289,7 @@ instance_methods:
     The function should take a `row` object for each row in the dataset. If a row shouldn't be modified, the function
     can return false for that row.
     This will fire <code>update</code> and <code>change</code> events on a syncable dataset.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataset.update")
+    = toRunnableCodeBlock("api/miso.dataset.update")
   params:
   -
     name: filter
@@ -324,6 +318,5 @@ instance_methods:
   returns: undefined
   description: |
     Updates one or more rows in a dataset. This will fire <code>update</code> and <code>change</code> events on a syncable dataset.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataset.reset")
+    = toRunnableCodeBlock("api/miso.dataset.reset")
 

--- a/src/other/miso.dataview.yaml
+++ b/src/other/miso.dataview.yaml
@@ -10,16 +10,14 @@ instance_methods:
   signature: 'ds.columnNames()'
   description: |
     Returns an array containing the names of all columns
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.columnnames")
+    = toRunnableCodeBlock("api/miso.dataview.columnnames")
   returns: 'Array'
 -
   name: 'column'
   signature: 'ds.column( name )'
   description: |
     Returns a reference to a column object
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.column")
+    = toRunnableCodeBlock("api/miso.dataview.column")
   returns: 'Array'
   params:
   -
@@ -34,8 +32,7 @@ instance_methods:
   signature: 'ds.columns( nameArray )'
   description: |
     Shorthand for ds.where({ columns : nameArray });
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.columns")
+    = toRunnableCodeBlock("api/miso.dataview.columns")
   returns: 'Miso.Dataset.DataView'
   params:
   -
@@ -48,8 +45,7 @@ instance_methods:
   signature: 'ds.hasColumn( name )'
   description: |
     Checks for the existance of a column and returns true/false
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.hascolumn")
+    = toRunnableCodeBlock("api/miso.dataview.hascolumn")
   returns: 'Boolean'
   params:
   -
@@ -63,8 +59,7 @@ instance_methods:
   description: |
     Iterate over all columns. Direct column references, not arrays so modifying
     data may cause internal inconsistencies.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.eachColumn")
+    = toRunnableCodeBlock("api/miso.dataview.eachColumn")
   returns: ''
   params:
   -
@@ -84,8 +79,7 @@ instance_methods:
   description: |
     Iterate over all rows. Each row is not a direct reference to the data
     and thus should not be altered in any way.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.each")
+    = toRunnableCodeBlock("api/miso.dataview.each")
   returns: ''
   params:
   -
@@ -105,8 +99,7 @@ instance_methods:
   description: |
     Iterate over all rows in reverse. Each row is not a direct reference to the data
     and thus should not be altered in any way.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.reverseEach")
+    = toRunnableCodeBlock("api/miso.dataview.reverseEach")
   returns: ''
   params:
   -
@@ -125,8 +118,7 @@ instance_methods:
   signature: 'ds.rowByPosition( position )'
   description: |
     Fetches a row object at a specified position. Note that the returned row object is NOT a direct reference to the data and thus any changes to it will not alter the original data.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.rowbyposition")
+    = toRunnableCodeBlock("api/miso.dataview.rowbyposition")
   returns: 'Object'
   params:
   -
@@ -140,8 +132,7 @@ instance_methods:
   signature: 'ds.rowById( id )'
   description: |
     Fetches a row object with a specific <code>_id</code>. Note that the returned row object is NOT a direct reference to the data and thus any changes to it will not alter the original data.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.rowbyid")
+    = toRunnableCodeBlock("api/miso.dataview.rowbyid")
   returns: 'Object'
   params:
   -
@@ -156,8 +147,7 @@ instance_methods:
     Shorthand for
     %a{ :href => '#misodataview_i_where' } ds.where({ rows : rowFilter });
     If run with no filter will return all rows.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.rows")
+    = toRunnableCodeBlock("api/miso.dataview.rows")
   returns: 'Miso.Dataset.DataView'
   params:
   -
@@ -173,8 +163,7 @@ instance_methods:
     Sorts the dataset according to the comparator. A comparator can either be passed
     in as part of the options object or have been defined on the dataset already, for
     example as part of the initialization block.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.sort")
+    = toRunnableCodeBlock("api/miso.dataview.sort")
   returns: 'Miso.Dataset.DataView'
   params:
   -
@@ -204,8 +193,7 @@ instance_methods:
     Filtration can be applied to both rows & columns and for syncing datasets changes
     in the parent dataset from which the dataview was created will be reflected in the
     dataview.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.where")
+    = toRunnableCodeBlock("api/miso.dataview.where")
   returns: Miso.Dataset.DataView
   params:
   -
@@ -229,8 +217,7 @@ instance_methods:
   signature: ds.groupBy(byColumn, columns, options)
   description: |
     Groups rows by the values in a given column
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.groupBy")
+    = toRunnableCodeBlock("api/miso.dataview.groupBy")
   params:
   -
     name: byColumn
@@ -265,8 +252,7 @@ instance_methods:
   returns: Miso.Dataset.Derived
   description: |
     Returns a new derived dataset that contains the original byColumn and a count column that returns the number of occurances each unique value in the byColumn contained.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.countBy")
+    = toRunnableCodeBlock("api/miso.dataview.countBy")
   params:
   -
     name: byColumn
@@ -311,8 +297,7 @@ instance_methods:
     If the dataset has <code>sync</code> enabled this will return a <code>Miso.Dataset.Product</code> that can
     be used to bind events to and access the current value. Otherwise it will return the current
     value - the lowest numeric value in that column
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.min")
+    = toRunnableCodeBlock("api/miso.dataview.min")
   params:
   -
     name: column
@@ -327,8 +312,7 @@ instance_methods:
     If the dataset has <code>sync</code> enabled this will return a <code>Miso.Dataset.Product</code> that can
     be used to bind events to and access the current value. Otherwise it will return the current
     value - the highest numeric value in that column
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.max")
+    = toRunnableCodeBlock("api/miso.dataview.max")
   params:
   -
     name: column
@@ -344,8 +328,7 @@ instance_methods:
     If the dataset has <code>sync</code> enabled this will return a <code>Miso.Dataset.Product</code> that can
     be used to bind events to and access the current value. Otherwise it will return the current
     value - the sum of the numeric form of the values in the column.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.sum")
+    = toRunnableCodeBlock("api/miso.dataview.sum")
   params:
   -
     name: column
@@ -360,8 +343,7 @@ instance_methods:
     If the dataset has <code>sync</code> enabled this will return a <code>Miso.Dataset.Product</code> that can
     be used to bind events to and access the current value. Otherwise it will return the current
     value - the mean or average of the numeric form of the values in the column.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.dataview.mean")
+    = toRunnableCodeBlock("api/miso.dataview.mean")
   params:
   -
     name: column

--- a/src/other/miso.event.yaml
+++ b/src/other/miso.event.yaml
@@ -14,8 +14,7 @@ methods:
   returns: Boolean
   description: |
     Returns whether or not a given delta is for a remove event
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.event.isremove")
+    = toRunnableCodeBlock("api/miso.event.isremove")
   params:
   -
     name: delta
@@ -29,8 +28,7 @@ methods:
   returns: Boolean
   description: |
     Returns whether or not a given delta is for an add event
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.event.isadd")
+    = toRunnableCodeBlock("api/miso.event.isadd")
   params:
   -
     name: delta
@@ -43,8 +41,7 @@ methods:
   returns: Boolean
   description: |
     Returns whether or not a given delta is for an update event
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.event.isupdate")
+    = toRunnableCodeBlock("api/miso.event.isupdate")
   params:
   -
     name: delta
@@ -58,6 +55,5 @@ instance_methods:
   returns: Array
   description: |
     Returns an array of columns affected by the event
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.event.affectedcolumns")
+    = toRunnableCodeBlock("api/miso.event.affectedcolumns")
 

--- a/src/other/miso.importers.local.yaml
+++ b/src/other/miso.importers.local.yaml
@@ -2,8 +2,7 @@
 name: Miso.Dataset.Importers.Local
 description: |
   Import local data already in the environment
-  %div{ :style=> 'height:200px'}
-    = toRunnableCodeBlock("api/miso.importer.local")
+  = toRunnableCodeBlock("api/miso.importer.local")
 methods:
 -
   name: constructor

--- a/src/other/miso.importers.polling.yaml
+++ b/src/other/miso.importers.polling.yaml
@@ -2,8 +2,7 @@
 name: Miso.Dataset.Importers.Polling
 description: |
   Pull data from a remote source on a regular interval
-  %div{ :style=> 'height:200px'}
-    = toRunnableCodeBlock("api/miso.importer.polling")
+  = toRunnableCodeBlock("api/miso.importer.polling")
 
 methods:
 -

--- a/src/other/miso.importers.remote.yaml
+++ b/src/other/miso.importers.remote.yaml
@@ -2,8 +2,7 @@
 name: Miso.Dataset.Importers.Remote
 description: |
   Import data from remote files via an AJAX request
-  %div{ :style=> 'height:200px'}
-    = toRunnableCodeBlock("api/miso.importer.remote")
+  = toRunnableCodeBlock("api/miso.importer.remote")
 methods:
 -
   name: constructor

--- a/src/other/miso.importers.yaml
+++ b/src/other/miso.importers.yaml
@@ -12,5 +12,4 @@ description: |
       %li <code>Miso.Dataset.Importers.GoogleSpreadsheet</code>
   %p
     An importer must implement the following interface:
-    %div{ :style=> 'height:200px'}
-      = toDisplayCodeBlock("api/importer")
+    = toDisplayCodeBlock("api/importer")

--- a/src/other/miso.product.yaml
+++ b/src/other/miso.product.yaml
@@ -14,8 +14,7 @@
     returns: Function
     description: |
       Use this method to define a new product. For example:
-      %div{ :style=> 'height:200px'}
-        = toRunnableCodeBlock("dataset/computations/custom")
+      = toRunnableCodeBlock("dataset/computations/custom")
     params:
     -
       name: 'func'
@@ -31,5 +30,4 @@
     returns: Any
     description: |
       Returns the current value of the product.
-      %div{ :style=> 'height:200px'}
-        = toRunnableCodeBlock("api/miso.product.val")
+      = toRunnableCodeBlock("api/miso.product.val")

--- a/src/other/miso.types.yaml
+++ b/src/other/miso.types.yaml
@@ -16,8 +16,7 @@ methods:
   description: |
     Typeof tests the type of a given input against the registered Miso types and
     returns the closest match.
-    %div{ :style=> 'height:200px'}
-      = toRunnableCodeBlock("api/miso.types.typeof")
+    = toRunnableCodeBlock("api/miso.types.typeof")
   params:
   -
     name: value


### PR DESCRIPTION
Integration with the ACE code editor is a little wonky right now. These changes fix the line numbering and editor height.

**Before:**

![misoproject com-code-block-before](https://cloud.githubusercontent.com/assets/677252/3163382/14947fa4-eb3f-11e3-850d-fe411e67d732.png)

**After:**

![misoproject com-code-block-after](https://cloud.githubusercontent.com/assets/677252/3163384/199233ca-eb3f-11e3-90bc-8686b3599ee5.png)

@iros I've only been able to do limited testing because of bizarre StaticMatic behavior. Could you test this for me?
